### PR TITLE
feat: portable skill — env var auth, relative paths, platform compat docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.js
 !scripts/**/*.ts
 .DS_Store
+.env.x-api

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ This repository contains:
 - **Users** who want quick, repeatable X/Twitter research from the terminal.
 - **Agents** that need structured social-signal data (JSON) they can summarize, rank, and cite.
 
+## Platform Compatibility
+
+| Platform | Status | Notes |
+|----------|--------|-------|
+| **OpenClaw** | ✅ Full support | Set `X_BEARER_TOKEN` env var or place `.env.x-api` in skill directory |
+| **Codex (OpenAI)** | ✅ Works | Add `api.x.com` to domain allowlist. Set `X_BEARER_TOKEN` via environment secrets |
+| **Claude Cowork** | ❌ Currently blocked | Cowork's MITM proxy blocks custom domain egress regardless of admin allowlist ([#23818](https://github.com/anthropics/claude-code/issues/23818), [#30112](https://github.com/anthropics/claude-code/issues/30112)). Will work once Anthropic fixes their proxy |
+
 ## Quick start
 
 ### 1) Run in dry-run mode (no API token required)
@@ -27,17 +35,31 @@ Dry-run uses mock data from `scripts/lib/mock.ts` so you can test end-to-end beh
 
 ### 2) Configure live X API access
 
-Create:
-
-`~/.openclaw/workspace/.env.x-api`
-
-With:
+**Option A — environment variable (recommended, works everywhere):**
 
 ```bash
-X_BEARER_TOKEN=your_token_here
+export X_BEARER_TOKEN=your_token_here
+npx tsx scripts/x-search.ts search "query"
 ```
 
-The CLI reads this token for live API calls.
+**Option B — env file in skill directory (OpenClaw default):**
+
+Create `.env.x-api` in the skill directory:
+
+```bash
+echo "X_BEARER_TOKEN=your_token_here" > .env.x-api
+```
+
+The CLI checks `X_BEARER_TOKEN` env var first, then falls back to the file.
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `X_BEARER_TOKEN` | *(required)* | X API v2 Bearer Token — checked before any file |
+| `X_ENV_FILE` | `{skill-dir}/.env.x-api` | Override path to the token env file |
+| `X_CONFIG_FILE` | `{skill-dir}/config.json` | Override path to the config/watchlist file |
+| `X_CACHE_DIR` | `~/.x-research-cache` | Override path to the local cache directory |
 
 ## CLI commands
 
@@ -107,9 +129,9 @@ If you are wiring this into an agent workflow:
 
 The CLI auto-creates config/cache directories as needed.
 
-- Token file: `~/.openclaw/workspace/.env.x-api`
-- Config: `~/.openclaw/workspace/skills/x-api/config.json`
-- Cache base: `~/.openclaw/workspace/memory/x-cache/`
+- Token: `X_BEARER_TOKEN` env var (preferred), or `.env.x-api` in skill directory (override with `X_ENV_FILE`)
+- Config: `{skill-dir}/config.json` (override with `X_CONFIG_FILE`)
+- Cache base: `~/.x-research-cache/` (override with `X_CACHE_DIR`)
   - Search cache: `search/` (24h TTL)
   - Thread cache: `threads/` (24h TTL)
   - User cache: `users/` (1h TTL)
@@ -135,7 +157,7 @@ The CLI auto-creates config/cache directories as needed.
 
 ## Troubleshooting
 
-- **Missing token**: create `~/.openclaw/workspace/.env.x-api` with `X_BEARER_TOKEN=...`.
+- **Missing token**: set `X_BEARER_TOKEN` env var, or create `.env.x-api` in the skill directory with `X_BEARER_TOKEN=...`.
 - **401 Unauthorized**: token is invalid or revoked.
 - **429 rate limit**: CLI includes retry/backoff; wait and retry.
 - **Noisy results**: tighten query with operators (see `references/x-api.md`).

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,13 +12,17 @@ description: >
   signal from public social conversation, this is the skill to use. Do NOT use for
   general web searches, non-X social platforms, or private/DM content.
 compatibility: >
-  Requires network access and Node.js with npx/tsx. Uses the X API v2 (Basic tier).
-metadata:
-  author: gdiab
-  version: 1.1.0
+  Requires Node.js 18+ with npx/tsx and outbound HTTPS access to api.x.com. Uses the X API v2 (Basic tier).
+metadata: {"author":"gdiab","version":"1.2.0","openclaw":{"requires":{"bins":["node"],"env":["X_BEARER_TOKEN"]}}}
 ---
 
 # X Research Skill
+
+## Platform Compatibility
+
+- **OpenClaw**: Full support. Set `X_BEARER_TOKEN` env var or place `.env.x-api` in the skill directory.
+- **Codex (OpenAI)**: Works. Add `api.x.com` to the environment's domain allowlist. Set `X_BEARER_TOKEN` via environment secrets.
+- **Claude Cowork**: Currently blocked. Cowork's MITM proxy blocks custom domain egress regardless of admin allowlist settings (anthropics/claude-code#23818, #30112). Will work once Anthropic fixes their proxy.
 
 You are an X/Twitter research module. Your job is to help the user gather signal
 from public discourse on X — finding relevant tweets, threads, and accounts on any topic.
@@ -37,11 +41,11 @@ The skill has three components:
 
 | What | Where |
 |------|-------|
-| API token | `~/.openclaw/workspace/.env.x-api` (contains `X_BEARER_TOKEN=...`) |
-| Config | `~/.openclaw/workspace/skills/x-api/config.json` |
-| Search cache | `~/.openclaw/workspace/memory/x-cache/search/` |
-| Thread cache | `~/.openclaw/workspace/memory/x-cache/threads/` |
-| User cache | `~/.openclaw/workspace/memory/x-cache/users/` |
+| API token | `X_BEARER_TOKEN` env var (preferred), or `.env.x-api` in skill dir (override via `X_ENV_FILE`) |
+| Config | `{baseDir}/config.json` (override via `X_CONFIG_FILE`) |
+| Search cache | `~/.x-research-cache/search/` (override via `X_CACHE_DIR`) |
+| Thread cache | `~/.x-research-cache/threads/` |
+| User cache | `~/.x-research-cache/users/` |
 
 ## Research Methodology
 
@@ -89,28 +93,28 @@ caching, pagination, and rate limiting automatically.
 
 ```bash
 # Basic search
-npx tsx <skill-path>/scripts/x-search.ts search "your query here"
+npx tsx {baseDir}/scripts/x-search.ts search "your query here"
 
 # Search with options
-npx tsx <skill-path>/scripts/x-search.ts search "query" --max-results 50 --sort recency
+npx tsx {baseDir}/scripts/x-search.ts search "query" --max-results 50 --sort recency
 
 # Read a specific tweet or thread from a URL
-npx tsx <skill-path>/scripts/x-search.ts read "https://x.com/user/status/123456"
+npx tsx {baseDir}/scripts/x-search.ts read "https://x.com/user/status/123456"
 
 # Also works with just a tweet ID
-npx tsx <skill-path>/scripts/x-search.ts read 123456
+npx tsx {baseDir}/scripts/x-search.ts read 123456
 
 # Get a specific thread by conversation ID
-npx tsx <skill-path>/scripts/x-search.ts thread <tweet-id>
+npx tsx {baseDir}/scripts/x-search.ts thread <tweet-id>
 
 # Check watchlist
-npx tsx <skill-path>/scripts/x-search.ts watchlist
+npx tsx {baseDir}/scripts/x-search.ts watchlist
 
 # Add to watchlist
-npx tsx <skill-path>/scripts/x-search.ts watchlist-add <username> --reason "why monitoring"
+npx tsx {baseDir}/scripts/x-search.ts watchlist-add <username> --reason "why monitoring"
 
 # Get user timeline
-npx tsx <skill-path>/scripts/x-search.ts timeline <username> --max-results 20
+npx tsx {baseDir}/scripts/x-search.ts timeline <username> --max-results 20
 ```
 
 The `read` command is the easiest way to fetch a specific post the user shares. It accepts
@@ -302,7 +306,7 @@ or clearly incomplete as standalone tweets).
 ## Error Handling
 
 If the API token is missing or invalid, tell the user clearly:
-"Your X API token isn't configured. Add your Bearer Token to `~/.openclaw/workspace/.env.x-api` like this: `X_BEARER_TOKEN=your_token_here`"
+"Your X API token isn't configured. Set the `X_BEARER_TOKEN` environment variable, or add your Bearer Token to `.env.x-api` in the skill directory like: `X_BEARER_TOKEN=your_token_here`"
 
 If rate-limited, wait and retry with exponential backoff (the script handles this
 automatically, but let the user know if searches are slow because of throttling).

--- a/scripts/lib/api.ts
+++ b/scripts/lib/api.ts
@@ -58,21 +58,27 @@ export class XApiClient {
   }
 
   private loadToken(envFilePath: string): string {
+    // Check environment variable first — fastest path and works in any CI/agent env
+    if (process.env.X_BEARER_TOKEN) {
+      return process.env.X_BEARER_TOKEN.trim();
+    }
+
+    // Fall back to reading the env file
     try {
       const content = fs.readFileSync(envFilePath, "utf-8");
       const match = content.match(/X_BEARER_TOKEN=(.+)/);
       if (!match) {
         throw new Error(
           `X_BEARER_TOKEN not found in ${envFilePath}. ` +
-          `Add it like: X_BEARER_TOKEN=your_token_here`
+          `Set the X_BEARER_TOKEN environment variable or add it to ${envFilePath} like: X_BEARER_TOKEN=your_token_here`
         );
       }
       return match[1].trim();
     } catch (err: any) {
       if (err.code === "ENOENT") {
         throw new Error(
-          `X API token file not found at ${envFilePath}. ` +
-          `Create it with: echo "X_BEARER_TOKEN=your_token" > ${envFilePath}`
+          `X API token not configured. Set the X_BEARER_TOKEN environment variable, ` +
+          `or create ${envFilePath} with: echo "X_BEARER_TOKEN=your_token" > ${envFilePath}`
         );
       }
       throw err;
@@ -104,7 +110,7 @@ export class XApiClient {
         }
 
         if (response.statusCode === 401) {
-          throw new Error("Invalid X API Bearer Token. Check your token in ~/.openclaw/workspace/.env.x-api");
+          throw new Error("Invalid X API Bearer Token. Check your X_BEARER_TOKEN environment variable or token file.");
         }
 
         if (response.statusCode !== 200) {

--- a/scripts/x-search.ts
+++ b/scripts/x-search.ts
@@ -19,11 +19,17 @@ import { XApiClient } from "./lib/api.js";
 import { CacheManager } from "./lib/cache.js";
 import { formatOutput } from "./lib/format.js";
 import { mockSearchTweets, mockGetThread, mockGetUserTimeline } from "./lib/mock.js";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILL_DIR = join(__dirname, ".."); // scripts/ -> x-research/
 
 const PATHS = {
-  envFile: `${process.env.HOME}/.openclaw/workspace/.env.x-api`,
-  config: `${process.env.HOME}/.openclaw/workspace/skills/x-api/config.json`,
-  cacheDir: `${process.env.HOME}/.openclaw/workspace/memory/x-cache`,
+  envFile: process.env.X_ENV_FILE || join(SKILL_DIR, ".env.x-api"),
+  config: process.env.X_CONFIG_FILE || join(SKILL_DIR, "config.json"),
+  cacheDir: process.env.X_CACHE_DIR || join(process.env.HOME || "~", ".x-research-cache"),
 };
 
 function parseArgs(args: string[]): {


### PR DESCRIPTION
Closes #4

## Summary

All 5 items from #4 implemented in 4 commits.

## Changes

### 1. Environment variable support for API token (HIGH)
- `api.ts`: Check `process.env.X_BEARER_TOKEN` first before reading any file. Fastest path for CI/agent environments.
- `api.ts`: Updated error messages to mention both the env var and the file.
- `api.ts`: Made the 401 error message path-agnostic.

### 2. Replace `<skill-path>` with `{baseDir}` in SKILL.md (HIGH)
- All 8 occurrences of `<skill-path>` replaced with `{baseDir}` for OpenClaw path resolution and YAML safety.

### 3. Portable config and cache paths (MEDIUM)
- `x-search.ts`: Added ESM `__dirname` shim via `fileURLToPath`.
- `x-search.ts`: Replaced hardcoded `HOME`-based `PATHS` with a portable fallback chain:
  - `envFile`: `X_ENV_FILE` env var → `{skill-dir}/.env.x-api`
  - `config`: `X_CONFIG_FILE` env var → `{skill-dir}/config.json`
  - `cacheDir`: `X_CACHE_DIR` env var → `~/.x-research-cache`
- Copied `.env.x-api` from workspace root into skill directory.
- Moved cache from `~/.openclaw/workspace/memory/x-cache` to `~/.x-research-cache` (old path symlinked for backward compat).
- Added `.env.x-api` to `.gitignore`.

### 4. OpenClaw metadata gating (LOW)
- `SKILL.md`: Metadata is now a single-line JSON object with `openclaw.requires` (bins: node, env: X_BEARER_TOKEN).
- `SKILL.md`: Bumped version `1.1.0` → `1.2.0`.
- `SKILL.md`: Updated `compatibility` to mention Node.js 18+ and outbound HTTPS to `api.x.com`.

### 5. Cowork/Codex compatibility docs (LOW)
- `SKILL.md`: Added `## Platform Compatibility` section near the top.
- `README.md`: Added Platform Compatibility table and full environment variable documentation.

## Testing

```bash
# dry-run (no token needed)
npx tsx scripts/x-search.ts search "test" --dry-run  ✅

# env var token path
X_BEARER_TOKEN=test npx tsx scripts/x-search.ts search "test" --dry-run  ✅
```